### PR TITLE
Enable Start on Boot and more QOL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,5 @@ FodyWeavers.xsd
 *.vsidx
 .vs/SatelliteWallpaperUpdater/v17/.suo
 *.pdb
+*.deploy
+/published

--- a/SatelliteWallpaperUpdater.Interfaces/Repositories/IEventLogRepository.cs
+++ b/SatelliteWallpaperUpdater.Interfaces/Repositories/IEventLogRepository.cs
@@ -4,6 +4,8 @@ namespace SatelliteWallpaperUpdater.Interfaces.Repositories
 {
     public interface IEventLogRepository
     {
-        void WriteToEventLog(string message, EventLogEntryType type);
+        public void WriteToEventLog(string message, EventLogEntryType type);
+
+        public bool EventLogSourceExists();
     }
 }

--- a/SatelliteWallpaperUpdater.Repositories/EventLogRepository.cs
+++ b/SatelliteWallpaperUpdater.Repositories/EventLogRepository.cs
@@ -28,5 +28,17 @@ namespace SatelliteWallpaperUpdater.Repositories
                 eventLog.WriteEntry(message, type);
             }
         }
+
+        public bool EventLogSourceExists()
+        {
+            try 
+            {
+                return EventLog.SourceExists(_appSettings.Value.ApplicationName);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
     }
 }

--- a/SatelliteWallpaperUpdater/Helpers/StartupHelper.cs
+++ b/SatelliteWallpaperUpdater/Helpers/StartupHelper.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Win32;
+using System.Reflection;
+using System.Security.Principal;
+
+namespace SatelliteWallpaperUpdater.Helpers
+{
+    public static class StartupHelper
+    {
+        public static void SetStartUp()
+        {
+            try
+            {
+                string appName = Assembly.GetExecutingAssembly().GetName().Name;
+                string appPath = string.Concat(AppDomain.CurrentDomain.BaseDirectory, "\\", appName, ".appref-ms");
+                string keyName = @"Software\Microsoft\Windows\CurrentVersion\Run";
+                using var key = Registry.CurrentUser.OpenSubKey(keyName, true);
+                
+                if (key != null)
+                {
+                    key.SetValue(appName, appPath);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error setting startup: {ex.Message}");
+            }
+        }
+
+        public static bool IsAdministrator()
+        {
+            var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+    }
+}

--- a/SatelliteWallpaperUpdater/Helpers/StartupHelper.cs
+++ b/SatelliteWallpaperUpdater/Helpers/StartupHelper.cs
@@ -11,14 +11,18 @@ namespace SatelliteWallpaperUpdater.Helpers
             try
             {
                 string appName = Assembly.GetExecutingAssembly().GetName().Name;
-                string appPath = string.Concat(AppDomain.CurrentDomain.BaseDirectory, "\\", appName, ".appref-ms");
+                string appPath = string.Concat(
+                    Environment.GetFolderPath(Environment.SpecialFolder.Programs),
+                    "\\Satellite Wallpaper Updater\\Satellite Wallpaper Updater", ".appref-ms");
                 string keyName = @"Software\Microsoft\Windows\CurrentVersion\Run";
-                using var key = Registry.CurrentUser.OpenSubKey(keyName, true);
-                
+                using var key = Registry.CurrentUser.OpenSubKey(keyName, true);                
+
                 if (key != null)
                 {
                     key.SetValue(appName, appPath);
                 }
+
+                key.Close();
             }
             catch (Exception ex)
             {

--- a/SatelliteWallpaperUpdater/Program.cs
+++ b/SatelliteWallpaperUpdater/Program.cs
@@ -16,17 +16,13 @@ namespace SatelliteWallpaperUpdater
         /// </summary>
         static void Main()
         {
-            // To customize application configuration such as set high DPI settings or default font,
-            // see https://aka.ms/applicationconfiguration.
             IConfiguration config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
+                .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
                 .AddJsonFile("appsettings.json", optional: false)
                 .Build();
 
-            //var builder = CreateHostBuilder(config).Build().RunAsync();
             var host = CreateHostBuilder(config).Build();
-            Application.Run(host.Services.GetRequiredService<MyApplicationContext>());
-            //Application.Run(new MyApplicationContext());
+            Application.Run(host.Services.GetRequiredService<WallpaperAppContext>());
         }
         static IHostBuilder CreateHostBuilder(IConfiguration config)
         {
@@ -38,7 +34,7 @@ namespace SatelliteWallpaperUpdater
 
                     // Services
                     services.AddSingleton<SatelliteDesktopUpdateService>();
-                    services.AddTransient<MyApplicationContext>();
+                    services.AddTransient<WallpaperAppContext>();
 
                     // Repositories
                     services.AddTransient<INESDISRepository, NESDISRepository>();

--- a/SatelliteWallpaperUpdater/Properties/PublishProfiles/ClickOnceProfile.pubxml
+++ b/SatelliteWallpaperUpdater/Properties/PublishProfiles/ClickOnceProfile.pubxml
@@ -2,7 +2,7 @@
 <!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
 <Project>
   <PropertyGroup>
-    <ApplicationRevision>11</ApplicationRevision>
+    <ApplicationRevision>0</ApplicationRevision>
     <ApplicationVersion>1.0.0.*</ApplicationVersion>
     <BootstrapperEnabled>True</BootstrapperEnabled>
     <Configuration>Release</Configuration>

--- a/SatelliteWallpaperUpdater/Properties/PublishProfiles/ClickOnceProfile.pubxml
+++ b/SatelliteWallpaperUpdater/Properties/PublishProfiles/ClickOnceProfile.pubxml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <ApplicationRevision>11</ApplicationRevision>
+    <ApplicationVersion>1.0.0.*</ApplicationVersion>
+    <BootstrapperEnabled>True</BootstrapperEnabled>
+    <Configuration>Release</Configuration>
+    <CreateWebPageOnPublish>False</CreateWebPageOnPublish>
+    <GenerateManifests>true</GenerateManifests>
+    <Install>True</Install>
+    <InstallFrom>Web</InstallFrom>
+    <InstallUrl>https://applicationbinaries.sfo3.digitaloceanspaces.com/SatelliteWallpaper/</InstallUrl>
+    <IsRevisionIncremented>True</IsRevisionIncremented>
+    <IsWebBootstrapper>True</IsWebBootstrapper>
+    <MapFileExtensions>False</MapFileExtensions>
+    <OpenBrowserOnPublish>False</OpenBrowserOnPublish>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net8.0-windows10.0.17763.0\win-x64\app.publish\</PublishDir>
+    <PublishUrl>C:\Users\jorda\Code\SatelliteWallpaperUpdater\published\</PublishUrl>
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishSingleFile>True</PublishSingleFile>
+    <SelfContained>True</SelfContained>
+    <SignatureAlgorithm>(none)</SignatureAlgorithm>
+    <SignManifests>False</SignManifests>
+    <SkipPublishVerification>false</SkipPublishVerification>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <UpdateEnabled>True</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateRequired>False</UpdateRequired>
+    <WebPageFileName>Publish.html</WebPageFileName>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <ProductName>Satellite Wallpaper Updater</ProductName>
+  </PropertyGroup>
+</Project>

--- a/SatelliteWallpaperUpdater/appsettings.json
+++ b/SatelliteWallpaperUpdater/appsettings.json
@@ -6,6 +6,6 @@
     }
   },
   "AppSettings": {
-    "ApplicationName": "Satellite Desktop Wallpaper Updater"
+    "ApplicationName": "Satellite Wallpaper Engine"
   }
 }


### PR DESCRIPTION
Enable start on boot to encourage updating at least when a user restarts. 

Overall ClickOnce is bad choice for hosting/deployment for modern .NET as ApplicationDeployment was never ported out of .Net Framework. That class allowed for initiating programmatic updates, but the methods are now gone. To act as a stop-gap for now (especially since other install methods aren't much easier or are also depreciated like Squirrel.Windows, we will really only check for updates when the user restarts their computer.

This isn't ideal for obvious reasons, but otherwise the exe is only ever run, and if we don't trigger the application reference file, we won't poll for updates.

> PS. All of this wouldn't be an issue if it wasn't for this app needing to be open all the time. Otherwise it would update when the user started it from the start menu.